### PR TITLE
Removing whitespace that was breaking linking

### DIFF
--- a/data/Java/books-and-ebooks/0002-oracle-secure.json
+++ b/data/Java/books-and-ebooks/0002-oracle-secure.json
@@ -1,7 +1,7 @@
 {
     "date": "2014-04-02",
     "free": true,
-    "name": "Secure Coding Guidelines for Java SE ",
+    "name": "Secure Coding Guidelines for Java SE",
     "remark": "Secure Java programming guidelines straight from Oracle.",
     "url": "http://www.oracle.com/technetwork/java/seccodeguide-139067.html"
 }


### PR DESCRIPTION
For some reason it looks like this whitespace was affecting the linking when using the readme. It was kind of bugging me. If you click the the second bullet point in the books and ebooks java section it won't take you to the proper place. Regenerating the read me should fix this with the space change. 

Thanks for making this repository by the way. Very useful! 
