### PR TITLE
Add Cossack Labs blog

### DIFF
--- a/data/00-general/websites/00-blogs/cossacklabs-blog
+++ b/data/00-general/websites/00-blogs/cossacklabs-blog
@@ -1,0 +1,7 @@
+{
+    "date": "2018-07-30",
+    "free": true,
+    "name": "Cossack Labs blog",
+    "remark": "Blog of cryptographic company that makes open-source libraries and tools, and describes practical data security approaches for applications and infrastructures.",
+    "url": "https://www.cossacklabs.com/blog-archive/"
+}


### PR DESCRIPTION
Cossack Labs are sharing tips from their cryptographic development, as well as basic-sanity data security advice.

Not sure what link is better to use – for [blog](https://www.cossacklabs.com/blog-archive/) or for [medium](https://medium.com/@cossacklabs), decided to add blog.