### PR TITLE
Add avatao to general websites

### DIFF
--- a/data/00-general/websites/0014-avatao.json
+++ b/data/00-general/websites/0014-avatao.json
@@ -1,0 +1,5 @@
+{
+    "name": "Avatao",
+    "remark": "Avatao is an online training platform offering a rich library of 600+ high-quality, hands-on IT security exercises to teach secure programming from design to deployment.",
+    "url": "https://platform.avatao.com/"
+}


### PR DESCRIPTION
I've added a link and a description of avatao to the general websites. Used 0014 for indexing, so no clashes with #43 .

Disclaimer: I'm currently employed by Avatao.com Innovative Learning Ltd.
