### PR TITLE
Add API Security in Action book link

### DIFF
--- a/data/00-general/books/0022-api-security-in-action.json
+++ b/data/00-general/books/0022-api-security-in-action.json
@@ -1,0 +1,7 @@
+{
+    "date": "2019-06-01",
+    "free": false,
+    "name": "API Security in Action",
+    "remark": "API Security in Action gives you the skills to build strong, safe APIs you can confidently expose to the world. It covers how to construct secure and scalable REST APIS, deliver machine-to-machine interaction in a microservices architecture, and provide protection in resource-constrained IoT environments.",
+    "url": "https://www.manning.com/books/api-security-in-action"
+}


### PR DESCRIPTION
This is a bit of shameless self-promotion (well, my publisher asked me to), but I wonder if you would be willing to add a link to my book, API Security in Action? (I can send you a link for a free copy if you want to read it first - it is still in "early access" so not complete yet).

It has a chapter on basic secure application development techniques, and then chapters covering CSRF, etc. It covers JWT because it is hard not to, but is clear to point out the security weaknesses and covers alternatives like Macaroons and Paseto :-) (I also mention CipherSweet in a section on database hardening, so Paragon IE is well covered...)