### PR TITLE
Add Poszo Next.js Security Headers Starter

### DIFF
--- a/data/00-general/websites/02-tools/0005-poszo-nextjs-security-headers-starter.json
+++ b/data/00-general/websites/02-tools/0005-poszo-nextjs-security-headers-starter.json
@@ -1,0 +1,5 @@
+{
+  "name": "Poszo Next.js Security Headers Starter",
+  "remark": "MIT-licensed, dependency-free Next.js response-header configurations with CSP guidance, rollback notes, and a deployed-site verifier for CI.",
+  "url": "https://github.com/poszothebuilder/nextjs-security-headers-starter"
+}


### PR DESCRIPTION
Adds one MIT-licensed Next.js security resource to General → Websites → Tools.

The starter provides dependency-free response-header configurations, CSP guidance, rollback notes, and a deployed-site verifier suitable for CI. The entry uses the repository’s required data-file format; README regeneration is left to the maintainers as documented.